### PR TITLE
build error fix, running on raspi 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(BUILD_EXAMPLES)
     file(GLOB SOURCES "apps/*.cc")
 
     add_executable(main ${SOURCES})
-    target_link_libraries(main PRIVATE distrifein)
+    target_link_libraries(main PRIVATE distrifein uuid)
 endif()
 
 # ========================================

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ Distributed, Decentralized, Fault-Tolerant Media Platform in C++
 - Reliable Broadcast
 - Uniform Reliable Broadcast
 
+#### Build Instructions
+
+1. Clone the repository with:
+```
+git clone https://github.com/ashwanirathee/distrifein.git
+```
+
+2.Update and add required packages
+```
+sudo apt update
+sudo apt install cmake uuid-dev
+```
+
+3. Then in root:
+```
+./build.sh or ./rebuild.sh
+```
+
 #### Example: image transfer via uniform reliable broadcast
 Displays the image of the uniform reliable broadcast protocol in action where I specify the file to be sent. It first puts the image in pending for itselfs and then waits for acks from the other nodes to deliver it. SID is the current sender id and Org SID is the original sender id. We wait for acks for all the correct processes to deliver the image before being saved to the disk:
 

--- a/include/distrifein/message.h
+++ b/include/distrifein/message.h
@@ -4,6 +4,8 @@
 #include <vector>
 #include <cstdint>
 #include <functional>
+#include <string_view>
+#include <cstring>
 
 // we ignore certain messages assuming they are always less than 30 bytes
 // like heartbeat messages in other applications

--- a/src/message.cc
+++ b/src/message.cc
@@ -1,6 +1,6 @@
 #include <distrifein/message.h>
 #include <iostream>
-
+#include <cstring>
 
 Message deserialize_message(const std::vector<uint8_t>& raw) {
     if (raw.size() < sizeof(MessageHeader)) {

--- a/src/utils.cc
+++ b/src/utils.cc
@@ -1,6 +1,7 @@
 #include <charconv>
 #include <distrifein/utils.h>
 #include <uuid/uuid.h>
+#include <cstring>
 
 using namespace std;
 


### PR DESCRIPTION
- Add file includes that were not working on raspberry
- Add build instructions
- Add uuid in build cmake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build configuration to improve compatibility with system libraries.
	- Added necessary standard library includes to enhance code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->